### PR TITLE
Improve LLM handling and traceability

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,13 @@ This is a tutorial project of [Pocket Flow](https://github.com/The-Pocket/Pocket
     - `-s, --max-size` - Maximum file size in bytes (default: 100KB)
     - `--language` - Language for the generated tutorial (default: "english")
     - `--max-abstractions` - Maximum number of abstractions to identify (default: 10)
+    - `--max-tokens` - Approximate maximum tokens per LLM prompt (default: 32000)
+    - `--llm-rate` - Approximate maximum LLM calls per minute (default: 30)
     - `--no-cache` - Disable LLM response caching (default: caching enabled)
 
 The application will crawl the repository, analyze the codebase structure, generate tutorial content in the specified language, and save the output in the specified directory (default: ./output).
+
+Code snippets in the generated chapters now include line numbers alongside file paths so you can easily trace explanations back to the original source.
 
 
 <details>

--- a/main.py
+++ b/main.py
@@ -56,6 +56,9 @@ def main():
     parser.add_argument("--no-cache", action="store_true", help="Disable LLM response caching (default: caching enabled)")
     # Add max_abstraction_num parameter to control the number of abstractions
     parser.add_argument("--max-abstractions", type=int, default=10, help="Maximum number of abstractions to identify (default: 10)")
+    # Control prompt token limit and rate
+    parser.add_argument("--max-tokens", type=int, default=32000, help="Approximate maximum tokens per LLM prompt")
+    parser.add_argument("--llm-rate", type=int, default=30, help="Approximate maximum LLM calls per minute")
 
     args = parser.parse_args()
 
@@ -87,6 +90,7 @@ def main():
         
         # Add max_abstraction_num parameter
         "max_abstraction_num": args.max_abstractions,
+        "max_prompt_tokens": args.max_tokens,
 
         # Outputs will be populated by the nodes
         "files": [],
@@ -100,6 +104,8 @@ def main():
     # Display starting message with repository/directory and language
     print(f"Starting tutorial generation for: {args.repo or args.dir} in {args.language.capitalize()} language")
     print(f"LLM caching: {'Disabled' if args.no_cache else 'Enabled'}")
+    os.environ['LLM_CALLS_PER_MIN'] = str(args.llm_rate)
+    os.environ['MAX_PROMPT_TOKENS'] = str(args.max_tokens)
 
     # Create the flow instance
     tutorial_flow = create_tutorial_flow()

--- a/utils/call_llm.py
+++ b/utils/call_llm.py
@@ -3,6 +3,7 @@ import os
 import logging
 import json
 from datetime import datetime
+import time
 
 # Configure logging
 log_directory = os.getenv("LOG_DIR", "logs")
@@ -24,11 +25,41 @@ logger.addHandler(file_handler)
 # Simple cache configuration
 cache_file = "llm_cache.json"
 
+# Rate limit and token settings
+CALLS_PER_MIN = int(os.getenv("LLM_CALLS_PER_MIN", "30"))
+MAX_PROMPT_TOKENS = int(os.getenv("MAX_PROMPT_TOKENS", "32000"))
+_call_timestamps = []  # track call times for rate limiting
+
+
+def _token_count(text: str) -> int:
+    """Rudimentary token counter based on whitespace."""
+    return len(text.split())
+
 
 # By default, we Google Gemini 2.5 pro, as it shows great performance for code understanding
 def call_llm(prompt: str, use_cache: bool = True) -> str:
-    # Log the prompt
+    """Send a prompt to the LLM with rudimentary rate limiting and token logs."""
+
+    # Rate limiting based on CALLS_PER_MIN
+    now = time.time()
+    global _call_timestamps
+    _call_timestamps = [t for t in _call_timestamps if now - t < 60]
+    if len(_call_timestamps) >= CALLS_PER_MIN:
+        sleep_time = 60 - (now - _call_timestamps[0])
+        if sleep_time > 0:
+            time.sleep(sleep_time)
+        now = time.time()
+        _call_timestamps = [t for t in _call_timestamps if now - t < 60]
+    _call_timestamps.append(now)
+
+    # Log the prompt and token count
+    token_len = _token_count(prompt)
+    logger.info(f"PROMPT_TOKENS: {token_len}")
     logger.info(f"PROMPT: {prompt}")
+    if token_len > MAX_PROMPT_TOKENS:
+        logger.warning(
+            f"Prompt length {token_len} exceeds MAX_PROMPT_TOKENS={MAX_PROMPT_TOKENS}"
+        )
 
     # Check cache if enabled
     if use_cache:


### PR DESCRIPTION
## Summary
- chunk LLM prompts in IdentifyAbstractions so large repos fit the context window
- add simple rate limiting and token logs in `call_llm`
- support numbered code snippets for traceability
- expose `--max-tokens` and `--llm-rate` CLI options
- document new options and numbered snippets in README and design docs

## Testing
- `python -m py_compile main.py nodes.py utils/call_llm.py`

------
https://chatgpt.com/codex/tasks/task_e_6843c726755883279b4ceeed2b1428fc